### PR TITLE
downgrade libxslt due to windows bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "commander": "^2.12.2",
         "enketo-xslt": "^1.15.1",
         "jsdom": "^11.5.1",
-        "libxslt": "^0.7.0"
+        "libxslt": "^0.6.5"
     },
     "devDependencies": {
         "aliasify": "^2.1.0",


### PR DESCRIPTION
- per https://github.com/enketo/enketo-transformer/issues/39
- prevents usage on windows
- allows more people to validate themselves :thumbsup: