### PR TITLE
fixed: repeat nodes in multiple default repeat instances get incorrec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![coverage-shield-badge-1](https://img.shields.io/badge/coverage-97.18%25-brightgreen.svg)
+![coverage-shield-badge-1](https://img.shields.io/badge/coverage-97.15%25-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/enketo-validate.svg)](http://badge.fury.io/js/enketo-validate) [![Build Status](https://travis-ci.org/enketo/enketo-validate.svg?branch=master)](https://travis-ci.org/enketo/enketo-validate) [![Dependency Status](https://david-dm.org/enketo/enketo-validate/status.svg)](https://david-dm.org/enketo/enketo-validate) [![devDependency Status](https://david-dm.org/enketo/enketo-validate/dev-status.svg)](https://david-dm.org/enketo/enketo-validate?type=dev)
 
 Enketo Validate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![coverage-shield-badge-1](https://img.shields.io/badge/coverage-97.05%25-brightgreen.svg)
+![coverage-shield-badge-1](https://img.shields.io/badge/coverage-97.18%25-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/enketo-validate.svg)](http://badge.fury.io/js/enketo-validate) [![Build Status](https://travis-ci.org/enketo/enketo-validate.svg?branch=master)](https://travis-ci.org/enketo/enketo-validate) [![Dependency Status](https://david-dm.org/enketo/enketo-validate/status.svg)](https://david-dm.org/enketo/enketo-validate) [![devDependency Status](https://david-dm.org/enketo/enketo-validate/dev-status.svg)](https://david-dm.org/enketo/enketo-validate?type=dev)
 
 Enketo Validate

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
       "dev": true
     },
     "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -807,9 +807,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
       "dev": true
     },
     "core-util-is": {
@@ -1035,22 +1035,21 @@
       }
     },
     "enketo-core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/enketo-core/-/enketo-core-5.5.1.tgz",
-      "integrity": "sha512-zoqQ8DGKozhJVHnHzk9Cw89PZIH6U2wQdBEt/sdacKa2wmbV8oCcyNS6KvSUQ7Nr+3z6M3obotH9DmKbwq9Qtw==",
+      "version": "github:enketo/enketo-core#b12d06290bc729ed47cb0fd1fd1806cd9952cd93",
+      "from": "github:enketo/enketo-core#b12d0629",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "bootstrap-datepicker": "1.9.x",
-        "core-js": "3.1.x",
-        "enketo-xpathjs": "1.9.2",
+        "core-js": "^3.2.1",
+        "enketo-xpathjs": "1.9.4",
         "html5sortable": "0.9.16",
         "jquery": "3.3.1",
         "jquery-touchswipe": "^1.6.19",
         "leaflet": "1.5.x",
         "leaflet-draw": "github:enketo/Leaflet.draw#ff73078",
         "leaflet.gridlayer.googlemutant": "0.8.x",
-        "mergexml": "1.1.2",
+        "mergexml": "1.2.1",
         "signature_pad": "2.3.x"
       }
     },
@@ -1059,9 +1058,9 @@
       "from": "git+https://github.com/OpenClinica/enketo-xpath-extensions-oc.git#22c6b94"
     },
     "enketo-xpathjs": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/enketo-xpathjs/-/enketo-xpathjs-1.9.2.tgz",
-      "integrity": "sha512-+WZNlgFlhzre9BfY3jkxRYWGl/Utxv/XHYU78TbRqQ/9NEQrWFwhSc2sgiB4ibIXsC2oygtMG83/5hw4Hb1uug==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/enketo-xpathjs/-/enketo-xpathjs-1.9.4.tgz",
+      "integrity": "sha512-1kIUwJQ4oXjPWuTzEER27pycfR/b9qgTsliorqg9B8Y9mjKQp4fEONKSlNOpvrIASDuOZvpSNrhvC2mmDVl8RA==",
       "dev": true
     },
     "enketo-xslt": {
@@ -1704,6 +1703,12 @@
           }
         }
       }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3019,10 +3024,15 @@
       "dev": true
     },
     "mergexml": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mergexml/-/mergexml-1.1.2.tgz",
-      "integrity": "sha1-2ocDqzl03lB7Pbrq4xWAIql/vjA=",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mergexml/-/mergexml-1.2.1.tgz",
+      "integrity": "sha512-IOW62CoY+QfpzsVrDhNG8hKAZnIRhmMldKfbl6/VAUecW6tUNWWtkWroCW4wSXaZp46GRwtUmZjGWCeK4FTS2w==",
+      "dev": true,
+      "requires": {
+        "formidable": "^1.2.1",
+        "xmldom": "^0.1.27",
+        "xpath": "0.0.27"
+      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -5153,6 +5163,18 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
       "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    },
+    "xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "chai": "^4.2.0",
         "docdash": "^1.1.1",
-        "enketo-core": "^5.5.1",
+        "enketo-core": "github:enketo/enketo-core#b12d0629",
         "eslint": "^6.1.0",
         "eslint-plugin-jsdoc": "^15.8.1",
         "istanbul-reporter-shield-badge": "^1.2.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import { parseFunctionFromExpression } from 'enketo-core/src/js/utils';
+import { getXPath } from 'enketo-core/src/js/dom-utils';
 import addXPathExtensionsOc from 'enketo-xpath-extensions-oc';
 
 /**
@@ -16,5 +17,6 @@ module.exports = {
      * @type function
      * @see {@link https://github.com/OpenClinica/enketo-xpath-extensions-oc|addXPathExtensionsOc}
      */
-    addXPathExtensionsOc
+    addXPathExtensionsOc,
+    getXPath
 };

--- a/src/xform.js
+++ b/src/xform.js
@@ -301,17 +301,16 @@ class XForm {
             }
             if ( children && children[ 0 ] ) {
                 const dataNodeNames = [];
-                const dataNodePaths = [];
-                [ ...children[ 0 ].querySelectorAll( '*' ) ].forEach( el => {
+                const dataNodes = children[ 0 ].querySelectorAll( '*' );
+
+                dataNodes.forEach( el => {
                     const nodeName = el.nodeName;
-                    const xPath = utils.getXPath( el, 'instance' );
                     const index = dataNodeNames.indexOf( nodeName );
-                    if ( index !== -1 && dataNodePaths[ index ] !== xPath ) {
+                    // Save XPath determination for when necessary, to not negatively affect performance.
+                    if ( index !== -1 && utils.getXPath( dataNodes[ index ], 'instance' ) !== utils.getXPath( el, 'instance' ) ) {
                         warnings.push( `Duplicate question or group name "${nodeName}" found. Unique names are recommended` );
-                    } else {
-                        dataNodeNames.push( nodeName );
-                        dataNodePaths.push( xPath );
                     }
+                    dataNodeNames.push( nodeName );
                 } );
             }
         }

--- a/src/xform.js
+++ b/src/xform.js
@@ -299,19 +299,20 @@ class XForm {
             if ( children && !children[ 0 ].id ) {
                 errors.push( `Data root node <${children[0].nodeName}> has no id attribute.` );
             }
-
-            // add warning for duplicate nodenames
-            const dataEl = children[0];
-            const dataNodes = dataEl.querySelectorAll( '*' );
-            if ( dataNodes.length > 0 ) {
-                let dataNodeNames = [];
-                dataNodes.forEach( dataNode => {
-                    dataNodeNames.push(dataNode.nodeName);
+            if ( children && children[ 0 ] ) {
+                const dataNodeNames = [];
+                const dataNodePaths = [];
+                [ ...children[ 0 ].querySelectorAll( '*' ) ].forEach( el => {
+                    const nodeName = el.nodeName;
+                    const xPath = utils.getXPath( el, 'instance' );
+                    const index = dataNodeNames.indexOf( nodeName );
+                    if ( index !== -1 && dataNodePaths[ index ] !== xPath ) {
+                        warnings.push( `Duplicate question or group name "${nodeName}" found. Unique names are recommended` );
+                    } else {
+                        dataNodeNames.push( nodeName );
+                        dataNodePaths.push( xPath );
+                    }
                 } );
-                const uniqueDataNodeNames = new Set( dataNodeNames );
-                if ( [ ...uniqueDataNodeNames ].length !== dataNodeNames.length ) {
-                    warnings.push('Duplicate nodenames found.');
-                }
             }
         }
 

--- a/test/spec/xform.spec.js
+++ b/test/spec/xform.spec.js
@@ -105,13 +105,13 @@ describe( 'XForm', () => {
 
         it( 'outputs errors for calculations without form control that refer to external ' +
             'clinicaldata instance but do not have the oc:external="clinicaldata" bind', () => {
-            expect( arrContains( result1.errors, /refers to external clinicaldata without the required "external" attribute/i ) ).to.equal( true );
-        } );
+                expect( arrContains( result1.errors, /refers to external clinicaldata without the required "external" attribute/i ) ).to.equal( true );
+            } );
 
         it( 'outputs errors for binds with oc:external="clinicaldata" that do not ' +
             'do not have a calculation that refers to instance(\'clinicaldata\')', () => {
-            expect( arrContains( result1.errors, /not .* calculation referring to instance\('clinicaldata'\)/i ) ).to.equal( true );
-        } );
+                expect( arrContains( result1.errors, /not .* calculation referring to instance\('clinicaldata'\)/i ) ).to.equal( true );
+            } );
     } );
 
     describe( 'with incorrect appearance usage', () => {
@@ -172,8 +172,10 @@ describe( 'XForm', () => {
         const result = validator.validate( xf );
 
         it( 'outputs warnings', () => {
-            expect( result.warnings.length ).to.equal( 1 );
-            expect( arrContains( result.warnings, /Duplicate nodenames found./i ) ).to.equal( true );
+            expect( result.warnings.length ).to.equal( 2 );
+            expect( arrContains( result.warnings, /Duplicate .* name "a" found/i ) ).to.equal( true );
+            expect( arrContains( result.warnings, /Duplicate .* name "g" found/i ) ).to.equal( true );
+            expect( arrContains( result.warnings, /Duplicate .* name "b" found/i ) ).to.equal( false );
         } );
 
     } );
@@ -191,11 +193,11 @@ describe( 'XForm', () => {
     } );
 } );
 
-describe('XForm Class', () => {
+describe( 'XForm Class', () => {
     it( 'should throw if XForm string not provided', () => {
         let failure = () => { new XForm(); };
         expect( failure ).to.throw();
-    });
+    } );
 
     describe( 'nsPrefixResolver method', () => {
         const xf = new XForm( loadXForm( 'model-only.xml' ) );
@@ -211,8 +213,8 @@ describe('XForm Class', () => {
         const xf = new XForm( loadXForm( 'model-only.xml' ) );
         it( 'should parse model if it wasn\'t parsed already', () => {
             expect( typeof xf.model === 'undefined' ).to.equal( true );
-            xf.enketoEvaluate('floor(1)');
+            xf.enketoEvaluate( 'floor(1)' );
             expect( typeof xf.model === 'undefined' ).to.equal( false );
         } );
     } );
-});
+} );

--- a/test/xform/duplicate-nodename.xml
+++ b/test/xform/duplicate-nodename.xml
@@ -13,8 +13,18 @@
                 <data id="data">
                     <a/>
                     <g>
+                        <!-- warning -->
                         <a/>
+                        <!-- another warning -->
+                        <g/>
                     </g>
+                    <rep>
+                        <b/>
+                    </rep>
+                    <rep>
+                        <!-- no warning because it is a repeat instance -->
+                        <b/>
+                    </rep>
                     <meta>
                         <instanceID/>
                     </meta>


### PR DESCRIPTION
…t 'duplicate' warning, closes #57

@gushil, I realized after approving your PR that an XForm could contain multiple repeat instances, in which case we do not want to output a warning. I got a little excited and made the change myself. If you would like to review, that would be much appreciated!

Also slipped in:
- If children[0] is empty the validation won't crash
- Output multiple messages if multiple duplicates occur in the same form
- Mention question/group name in warning message to help users fix the issue.


To test this you need to run `npm install && npm run prepublish` first.